### PR TITLE
Fix for new SQLite adapter name

### DIFF
--- a/lib/sql_origin.rb
+++ b/lib/sql_origin.rb
@@ -21,7 +21,7 @@ module SQLOrigin
   # Enables SQL:Origin backtrace logging to the Rails log.
 
   def self.append_to_log
-    %w( PostgreSQLAdapter MysqlAdapter Mysql2Adapter OracleAdapter SQLiteAdapter ).each do |name|
+    %w( PostgreSQLAdapter MysqlAdapter Mysql2Adapter OracleAdapter SQLiteAdapter SQLite3Adapter ).each do |name|
       adapter = ActiveRecord::ConnectionAdapters.const_get(name.to_sym) rescue nil
       if adapter
         adapter.send :include, SQLOrigin::LogHook


### PR DESCRIPTION
The new SQLite adapter includes the version number, as can be seen in the api docs:
http://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SQLite3Adapter.html

I did not remove the old adapter name for backward capabilities. 
